### PR TITLE
Update l10n.cpp

### DIFF
--- a/src/l10n.cpp
+++ b/src/l10n.cpp
@@ -49,7 +49,16 @@ enum {
   BT_COUNT
 };
 
+#if 1
+/* 
+   Must init {selected_language} later, else {-1} error  
+   value persists.
+ */
+int selected_language = -1 ; 
+#else
 int selected_language = LANG_EN;
+#endif
+
 Fl_Menu_Item item_month[13];
 
 static const char *buttons[LANG_COUNT][BT_COUNT] =
@@ -324,7 +333,21 @@ void l10n(void)
   }
 
   if (strncmp("en", env, 2) == 0 || strcmp("C", env) == 0) {
+#if 1
+   // <<<new code>>>
+    
+   // Specifiy ENglish language.
+   selected_language = LANG_EN ;   
+    
+   /*
+     Now we move onto init of 
+     {fl_{ok, cancel, yes, no, close}, item_month}
+     below.
+   */       
+#else   
+    // <<<old code>>>
     return;
+#endif    
   } else if (strncmp(env, "ar", 2) == 0) {
     selected_language = LANG_AR;
   } else if (strncmp(env, "de", 2) == 0) {


### PR DESCRIPTION
The {--calendar, --date} options for the "fltk-dialog" utility had a non-functional {Fl_Choice} widget for the month field.
The "bug" is related to the {l10n()} function not running it's full course; i.e. for "English" locale, initialization of {item_month} does not occur; same for {fl_ok, fl_cancel, fl_yes, fl_no, fl_close}.
An initialized {item_month} is required for init of the "menu" state of the respective {FL_Choice} widget.

The {selected_language} variable in {l10n.cpp} file was defaulted to {LANG_EN} in global space (i.e. outside {l10n()} function) and then this {LANG_EN} scenario was not properly handled in the {l10n()} function.

With the respective changes, the commands
"fltk-dialog --date"
"fltk-dialog --calendar"
now work on my system (Linux; i.e. Debian 9).